### PR TITLE
feat: add macos accessibility snapshot and interaction library

### DIFF
--- a/screenpipe-vision/src/accessibility_snapshot.rs
+++ b/screenpipe-vision/src/accessibility_snapshot.rs
@@ -1,0 +1,629 @@
+// Learn more about Tauri commands at https://tauri.app/develop/calling-rust/
+use serde::Serialize;
+use serde::Deserialize;
+use core_foundation::dictionary::{CFDictionary, CFDictionaryRef};
+use core_foundation::boolean::CFBoolean;
+use core_foundation::base::TCFType;
+
+use std::sync::Arc;
+use std::time::Duration;
+use rand::Rng;
+use rand::rngs::StdRng;
+use rand::SeedableRng;
+use tauri::Manager;
+use tauri::PhysicalPosition;
+use tauri::PhysicalSize;
+use tauri::{TitleBarStyle, WebviewWindowBuilder};
+use tauri_utils::config::WebviewUrl;
+use std::collections::HashSet;
+use std::sync::Mutex;
+use once_cell::sync::Lazy;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::ffi::{CString, CStr};
+use std::os::raw::{c_char, c_void};
+use tauri::webview::Color;
+
+// Add a static set to track context files
+static CONTEXT_FILES: Lazy<Mutex<HashSet<String>>> = Lazy::new(|| Mutex::new(HashSet::new()));
+
+// A simple structure for UI element information.
+#[derive(Serialize)]
+pub struct UIElement {
+    pub role: String,
+    pub label: String,
+    pub value: String,
+    pub x: f64,
+    pub y: f64,
+}
+
+// Track window labels to manage cleanup
+static OVERLAY_WINDOW_LABELS: Lazy<Mutex<HashSet<String>>> = Lazy::new(|| Mutex::new(HashSet::new()));
+static IS_POLLING: Lazy<AtomicBool> = Lazy::new(|| AtomicBool::new(false));
+
+
+#[cfg(target_os = "macos")]
+mod ffi {
+    use std::os::raw::c_char;
+    extern "C" {
+        pub fn perform_type_action(cElementId: *const c_char, cText: *const c_char) -> *mut c_char;
+        #[link_name = "perform_named_action"]
+        pub fn named_action(cElementId: *const c_char, cActionName: *const c_char) -> *mut c_char;
+        pub fn get_accessibility_hierarchy() -> *mut c_char;
+        pub fn get_accessibility_hierarchy_filtered(
+            app_name: *const c_char,
+            window_title: *const c_char
+        ) -> *mut c_char;
+    }
+}
+
+#[tauri::command]
+fn fetch_ui_elements() -> Vec<UIElement> {
+    #[cfg(target_os = "macos")]
+    {
+        return macos_accessibility::get_ui_elements();
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        // Print a warning if not running on macOS.
+        println!("Warning: fetch_ui_elements is only supported on macOS. Returning an empty vector.");
+        // If not running on macOS, return an empty vector.
+        return vec![];
+    }
+}
+
+#[cfg(target_os = "macos")]
+mod macos_accessibility {
+    use super::ffi;
+    use super::UIElement;
+    use std::os::raw::{c_void, c_char};
+    use std::ffi::{CString, CStr};
+    use std::ptr;
+    use core_foundation::{
+        array::CFArray,
+        base::{CFRelease, CFTypeRef, TCFType},
+        string::{CFString, CFStringRef},
+    };
+    use core_foundation_sys::array::CFArrayGetValueAtIndex;
+    use core_graphics::geometry::CGPoint;
+    use core_foundation_sys::base::OSStatus;
+    use core_foundation::dictionary::CFDictionaryRef;
+    use core_foundation::boolean::CFBoolean;
+    use core_foundation::dictionary::CFDictionary;
+
+    // An opaque pointer type representing an AXUIElement.
+    pub type AXUIElementRef = *mut c_void;
+    pub type AXValueRef = *mut c_void;
+    pub type AXValueType = u32;
+    pub const K_AXVALUE_CGPOINT_TYPE: AXValueType = 2; // Typically, 2 represents a CGPoint type.
+
+    #[link(name = "ApplicationServices", kind = "framework")]
+    extern "C" {
+        pub fn AXUIElementCreateSystemWide() -> AXUIElementRef;
+        pub fn AXUIElementCopyAttributeValue(
+            element: AXUIElementRef,
+            attribute: CFStringRef,
+            value: *mut CFTypeRef,
+        ) -> OSStatus;
+        pub fn AXValueGetValue(
+            value: AXValueRef,
+            theType: AXValueType,
+            valuePtr: *mut c_void,
+        ) -> i32;
+        pub fn AXIsProcessTrustedWithOptions(options: CFDictionaryRef) -> bool;
+        fn get_accessibility_hierarchy() -> *mut c_char;
+    }
+
+    /// Safely fetch an accessibility attribute as a Rust String.
+    pub unsafe fn get_attribute_string(element: AXUIElementRef, attribute: &str) -> Option<String> {
+        println!("Fetching attribute string for: {}", attribute);
+        let attr = CFString::new(attribute);
+        let mut value: CFTypeRef = ptr::null();
+        let result = AXUIElementCopyAttributeValue(element, attr.as_concrete_TypeRef(), &mut value);
+        println!("Result of AXUIElementCopyAttributeValue: {}", result);
+        if result != 0 || value.is_null() {
+            println!("Failed to get attribute string for: {}", attribute);
+            return None;
+        }
+        // Assume the returned value is a CFString.
+        let cf_str = CFString::wrap_under_create_rule(value as *mut _);
+        let string = cf_str.to_string();
+        CFRelease(value);
+        Some(string)
+    }
+
+    /// Fetch an accessibility attribute expected to be a CGPoint (using "AXPosition").
+    pub unsafe fn get_attribute_position(element: AXUIElementRef, attribute: &str) -> Option<(f64, f64)> {
+        println!("Fetching attribute position for: {}", attribute);
+        let attr = CFString::new(attribute);
+        let mut value: CFTypeRef = ptr::null();
+        let result = AXUIElementCopyAttributeValue(element, attr.as_concrete_TypeRef(), &mut value);
+        println!("Result of AXUIElementCopyAttributeValue: {}", result);
+        if result != 0 || value.is_null() {
+            println!("Failed to get attribute position for: {}", attribute);
+            return None;
+        }
+        let ax_value = value as AXValueRef;
+        let mut point = CGPoint { x: 0.0, y: 0.0 };
+        let success = AXValueGetValue(ax_value, K_AXVALUE_CGPOINT_TYPE, &mut point as *mut _ as *mut c_void);
+        if success == 0 {
+            CFRelease(value);
+            return None;
+        }
+        CFRelease(value);
+        Some((point.x as f64, point.y as f64))
+    }
+
+    /// Retrieve the children (AXChildren) of an accessibility element.
+    pub unsafe fn get_attribute_children(element: AXUIElementRef) -> Option<CFArray<*mut c_void>> {
+        println!("Fetching children for element");
+        let attr = CFString::new("AXChildren");
+        let mut value: CFTypeRef = ptr::null();
+        let result = AXUIElementCopyAttributeValue(element, attr.as_concrete_TypeRef(), &mut value);
+        println!("Result of AXUIElementCopyAttributeValue: {}", result);
+        if result != 0 || value.is_null() {
+            println!("Failed to get children for element");
+            return None;
+        }
+        Some(CFArray::wrap_under_create_rule(value as *mut _))
+    }
+
+    /// Recursively traverse the UI element hierarchy and collect those with interactive roles.
+    pub unsafe fn traverse_ui_elements(element: AXUIElementRef, elements: &mut Vec<UIElement>) {
+        println!("Traversing UI elements");
+        // Try to obtain the role, title (or label), value, and position.
+        let role = get_attribute_string(element, "AXRole");
+        let title = get_attribute_string(element, "AXTitle")
+            .or_else(|| get_attribute_string(element, "AXLabel"));
+        let value_attr = get_attribute_string(element, "AXValue");
+        let position = get_attribute_position(element, "AXPosition");
+
+        if let Some(pos) = position {
+            if let Some(role_str) = role {
+                println!("Found element with role: {}", role_str);
+                // For this demo, treat only a few common roles as interactive.
+                let interactive_roles = ["AXButton", "AXSlider", "AXTextField", "AXCheckBox"];
+                if interactive_roles.contains(&role_str.as_str()) {
+                    let label = title.unwrap_or_default();
+                    let value_str = value_attr.unwrap_or_default();
+                    elements.push(UIElement {
+                        role: role_str,
+                        label,
+                        value: value_str,
+                        x: pos.0,
+                        y: pos.1,
+                    });
+                }
+            }
+        }
+
+        // Traverse children if available.
+        if let Some(children_array) = get_attribute_children(element) {
+            let count = children_array.len();
+            for i in 0..count {
+                let child_ptr = CFArrayGetValueAtIndex(children_array.as_concrete_TypeRef(), i) as AXUIElementRef;
+                if !child_ptr.is_null() {
+                    traverse_ui_elements(child_ptr, elements);
+                }
+            }
+        }
+    }
+
+    /// Returns a vector of UIElement structures, obtained by starting at the focused window.
+    pub fn get_ui_elements() -> Vec<UIElement> {
+        println!("================================================");
+        println!("Getting UI elements");
+        let mut elements: Vec<UIElement> = Vec::new();
+        unsafe {
+
+            // Check if accessibility permissions have been granted.
+            let check_attr = CFString::new("AXTrustedCheckOptionPrompt");
+            let options: CFDictionaryRef = CFDictionary::from_CFType_pairs(&[
+                (check_attr.as_CFType(), CFBoolean::true_value().as_CFType())
+            ]).as_concrete_TypeRef();
+
+            let accessibility_enabled = {
+                let result = AXIsProcessTrustedWithOptions(options);
+                result
+            };
+
+            if accessibility_enabled {
+                println!("Accessibility permissions have been granted.");
+            } else {
+                println!("Error: Accessibility permissions have not been granted.");
+                return elements;
+            }
+
+            // Create a system-wide accessibility element.
+            let system_wide = AXUIElementCreateSystemWide();
+            // Attempt to get the currently focused window.
+            let focused_attr = CFString::new("AXFocusedWindow");
+            let mut focused_window_ptr: CFTypeRef = ptr::null();
+            let result = AXUIElementCopyAttributeValue(
+                system_wide,
+                focused_attr.as_concrete_TypeRef(),
+                &mut focused_window_ptr,
+            );
+
+            if result != 0 {
+                println!("Error: Failed to get focused window attribute. Result code: {}", result);
+            }
+
+            if focused_window_ptr.is_null() {
+                println!("Warning: Focused window pointer is null. Using system-wide element.");
+            }
+
+            let focused_window = if result == 0 && !focused_window_ptr.is_null() {
+                focused_window_ptr as AXUIElementRef
+            } else {
+                // If no focused window is available, fallback to the system‑wide element.
+                system_wide
+            };
+
+            // Recursively scan the element tree.
+            traverse_ui_elements(focused_window, &mut elements);
+
+            if !focused_window_ptr.is_null() {
+                CFRelease(focused_window_ptr);
+            }
+        }
+        println!("Total UI elements found: {}", elements.len());
+        println!("================================================");
+        elements
+    }
+
+    pub async fn get_accessibility_snapshot(
+        target_app: Option<String>,
+        target_window: Option<String>
+    ) -> String {
+        tokio::task::spawn_blocking(move || {
+            unsafe {
+                // println!("Getting accessibility snapshot");
+                // if let Some(app_name) = &target_app {
+                //     println!("Filtering for app: {}", app_name);
+                // }
+                // if let Some(window_name) = &target_window {
+                //     println!("Filtering for window: {}", window_name);
+                // }
+
+                let start = std::time::Instant::now();
+
+                let c_str = match (target_app, target_window) {
+                    (Some(app), Some(window)) => {
+                        let c_app = CString::new(app).unwrap();
+                        let c_window = CString::new(window).unwrap();
+                        ffi::get_accessibility_hierarchy_filtered(
+                            c_app.as_ptr(),
+                            c_window.as_ptr()
+                        )
+                    },
+                    (Some(app), None) => {
+                        let c_app = CString::new(app).unwrap();
+                        ffi::get_accessibility_hierarchy_filtered(
+                            c_app.as_ptr(),
+                            std::ptr::null()
+                        )
+                    },
+                    (None, Some(window)) => {
+                        let c_window = CString::new(window).unwrap();
+                        ffi::get_accessibility_hierarchy_filtered(
+                            std::ptr::null(),
+                            c_window.as_ptr()
+                        )
+                    },
+                    (None, None) => ffi::get_accessibility_hierarchy()
+                };
+
+                let duration = start.elapsed();
+                // println!("get_accessibility_hierarchy took {:?}", duration);
+
+                if c_str.is_null() {
+                    return String::from("{\"error\": \"Failed to get accessibility hierarchy\"}");
+                }
+                let result = CStr::from_ptr(c_str)
+                    .to_string_lossy()
+                    .into_owned();
+                // Free the string allocated by strdup in Swift
+                libc::free(c_str as *mut c_void);
+                result
+            }
+        })
+        .await
+        .unwrap_or_else(|_| String::from("{\"error\": \"Failed to execute task\"}"))
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn prompt_for_accessibility_permissions() {
+    use core_foundation::dictionary::CFDictionary;
+    use core_foundation::string::CFString;
+    use core_foundation::boolean::CFBoolean;
+    use core_foundation::base::TCFType;
+    use core_foundation_sys::dictionary::CFDictionaryRef;
+    use std::os::raw::c_void;
+
+    // kAXTrustedCheckOptionPrompt is used to show the prompt if required.
+    let key = CFString::new("AXTrustedCheckOptionPrompt");
+    let value = CFBoolean::true_value();
+
+    // Create a dictionary via a slice of (key, value) pairs.
+    // This returns a CFDictionary<CFString, CFBoolean>
+    let options_dict = CFDictionary::from_CFType_pairs(&[(key, value)]);
+    // Cast the dictionary to the raw type that is expected (CFDictionaryRef)
+    let options_dict_ref: CFDictionaryRef = options_dict.as_concrete_TypeRef();
+
+    // Call the external function to check for trust and to prompt if necessary.
+    unsafe {
+        let trusted = macos_accessibility::AXIsProcessTrustedWithOptions(options_dict_ref);
+        if !trusted {
+            println!("Accessibility permissions are not granted. Please enable them in System Preferences.");
+        }
+    }
+}
+
+#[tauri::command]
+async fn get_accessibility_snapshot(
+  target_app: Option<String>,
+  target_window: Option<String>
+) -> String {
+    #[cfg(target_os = "macos")]
+    {
+        macos_accessibility::get_accessibility_snapshot(
+          target_app,
+          target_window
+        ).await
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        String::from("{\"error\": \"This feature is only available on macOS\"}")
+    }
+}
+
+#[derive(serde::Deserialize, serde::Serialize)]
+struct UIFrameData {
+    e: Vec<UIFrameElement>,
+}
+
+#[derive(serde::Deserialize, serde::Serialize, Clone, Debug)]
+struct UIFrameElement {
+    id: Option<String>,  // unique identifier
+    e: String,  // element type
+    p: Option<String>,  // path
+    d: Option<u32>,  // depth
+    f: Option<Vec<f64>>,  // frame [x, y, width, height]
+    a: Option<std::collections::HashMap<String, String>>,  // attributes
+    m: Option<Vec<String>>,  // methods (actions)
+    c: Option<Vec<UIFrameElement>>,  // children
+    app: Option<String>,  // app
+    focused: Option<bool>,  // focused
+
+    #[serde(skip)]
+    selected_text_bounds: Option<(f64, f64, f64, f64)>  // (x, y, width, height) of selected text if any
+}
+
+impl UIFrameElement {
+    // Helper method to parse and get selected text bounds
+    fn get_selected_text_bounds(&self) -> Option<(f64, f64, f64, f64)> {
+        if let Some(attrs) = &self.a {
+            if let Some(bounds_str) = attrs.get("AXSelectedTextBounds") {
+                let parts: Vec<f64> = bounds_str
+                    .split(',')
+                    .filter_map(|s| s.parse().ok())
+                    .collect();
+
+                if parts.len() == 4 {
+                    return Some((parts[0], parts[1], parts[2], parts[3]));
+                }
+            }
+        }
+        None
+    }
+
+    // Helper method to check if this element represents our own app
+    fn is_self_app(&self) -> bool {
+        if let Some(app_name) = &self.app {
+            app_name.to_lowercase().contains("alvea")
+        } else {
+            false
+        }
+    }
+}
+
+// Recursively collect input elements from the UI hierarchy
+fn collect_input_elements(element: &UIFrameElement, elements: &mut Vec<UIFrameElement>) {
+    // Check if current element is an input type
+    if is_input_element(&element.e) {
+        elements.push(element.clone());
+    }
+
+    // Recursively process children
+    if let Some(children) = &element.c {
+        for child in children {
+            collect_input_elements(child, elements);
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct LastSelectionContext {
+    app_element: UIFrameElement,
+    // window_element: UIFrameElement,
+    // selection_element: UIFrameElement,
+}
+
+static LAST_SELECTION_CONTEXT: Lazy<Mutex<Option<LastSelectionContext>>> = Lazy::new(|| Mutex::new(None));
+
+#[tauri::command]
+async fn start_accessibility_polling(app_handle: tauri::AppHandle) {
+    println!("Starting accessibility polling");
+    IS_POLLING.store(true, Ordering::SeqCst);
+    let app_handle_clone = app_handle.clone();
+
+    tauri::async_runtime::spawn(async move {
+        while IS_POLLING.load(Ordering::SeqCst) {
+            // Get the last known context for targeted snapshot
+            let last_context = LAST_SELECTION_CONTEXT.lock().unwrap().clone();
+            // println!("Last context: {:?}", last_context);
+
+            let (target_app) = if let Some(ctx) = &last_context {
+                println!("Using last context - App: {:?}",
+                    ctx.app_element.app);
+
+                (ctx.app_element.app.clone())
+            } else {
+                (None)
+            };
+
+            println!("Getting accessibility snapshot");
+            println!("Target app: {:?}", target_app);
+            let target_window = None;
+            println!("Target window: {:?}", target_window);
+
+            if let Ok(snapshot) = serde_json::from_str::<UIFrameData>(
+                &get_accessibility_snapshot(target_app, target_window).await
+            ) {
+                println!("Got accessibility snapshot with {} root elements", snapshot.e.len());
+
+                let mut current_app_is_self = false;
+                let mut found_text_selection = false;
+                let mut input_elements = Vec::new();
+
+                for root_element in &snapshot.e {
+                    // Check if current app is self (Alvea) at root level
+                    // if let Some(app_name) = &root_element.app {
+                    //     println!("Root element app: {}", app_name);
+                    // }
+                    if root_element.is_self_app() {
+                        current_app_is_self = true;
+                        // println!("Current app is Alvea (self)");
+                        break;
+                    } else {
+                        // Store the current selection context if it's not from our app
+                        let mut last_context = LAST_SELECTION_CONTEXT.lock().unwrap();
+                        *last_context = Some(LastSelectionContext {
+                          app_element: root_element.clone(),
+                          // window_element,
+                          // selection_element: element.clone(),
+                        });
+                    }
+                    collect_input_elements(root_element, &mut input_elements);
+                }
+                println!("Collected {} input elements", input_elements.len());
+
+                {
+                    // Manage overlay window labels.
+                    let mut window_labels = OVERLAY_WINDOW_LABELS.lock().unwrap();
+                    let mut current_labels = HashSet::new();
+
+                    for (idx, element) in input_elements.iter().enumerate() {
+                        // Check for text selection
+                        if let Some(bounds) = element.get_selected_text_bounds() {
+                            found_text_selection = true;
+                            println!("Found text selection in element");
+
+                            let label = format!("overlay_{}_selection", idx);
+                            current_labels.insert(label.clone());
+                            // println!("Showing overlay window: {}", label);
+
+                            println!("Text selection bounds: x={}, y={}, width={}, height={}", 
+                                bounds.0, bounds.1, bounds.2, bounds.3);
+
+                        }
+                    }
+
+                    // Log the window labels before cleanup
+                    println!("Current labels: {:?}", current_labels);
+                    println!("Existing window labels: {:?}", window_labels);
+
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(200)).await;
+        }
+
+    });
+}
+
+#[tauri::command]
+async fn stop_accessibility_polling() {
+    IS_POLLING.store(false, Ordering::SeqCst);
+}
+
+fn is_input_element(role: &str) -> bool {
+    let input_types = [
+        "AXTextField",
+        "AXTextArea",
+        "AXButton",
+        "AXCheckBox",
+        "AXRadioButton",
+        "AXSlider",
+        "AXComboBox",
+        "AXPopUpButton",
+    ];
+    input_types.iter().any(|&t| role.ends_with(t))
+}
+
+#[tauri::command]
+fn perform_typing_action(element_id: String, text: String) -> Result<String, String> {
+    #[cfg(target_os = "macos")]
+    {
+         println!("Performing typing action on element: {} with text: {}", element_id, text);
+         let c_element_id = CString::new(element_id).map_err(|e| e.to_string())?;
+         let c_text = CString::new(text).map_err(|e| e.to_string())?;
+         unsafe {
+             let result = ffi::perform_type_action(c_element_id.as_ptr(), c_text.as_ptr());
+             if result.is_null() {
+                 return Err("Failed to perform typing action".into());
+             }
+             let result_str = CStr::from_ptr(result).to_string_lossy().into_owned();
+             libc::free(result as *mut libc::c_void);
+             Ok(result_str)
+         }
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+         Err("This feature is only available on macOS".into())
+    }
+}
+
+#[tauri::command]
+fn perform_named_action(element_id: String, action_name: String) -> Result<(), String> {
+    #[cfg(target_os = "macos")]
+    {
+         println!("Performing named action on element: {} with action: {}", element_id, action_name);
+         let c_element_id = CString::new(element_id).map_err(|e| e.to_string())?;
+         let c_action_name = CString::new(action_name).map_err(|e| e.to_string())?;
+         unsafe {
+             let result = ffi::named_action(c_element_id.as_ptr(), c_action_name.as_ptr());
+             if result.is_null() {
+                 return Err("Failed to perform named action".into());
+             }
+             let result_str = CStr::from_ptr(result).to_string_lossy().into_owned();
+             libc::free(result as *mut libc::c_void);
+             if result_str.contains("success") {
+                 Ok(())
+             } else {
+                 Err(result_str)
+             }
+         }
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+         Err("This feature is only available on macOS".into())
+    }
+}
+
+#[cfg_attr(mobile, tauri::mobile_entry_point)]
+pub fn run() {
+    tauri::Builder::default()
+        .invoke_handler(tauri::generate_handler![
+            fetch_ui_elements,
+            get_accessibility_snapshot,
+            start_accessibility_polling,
+            stop_accessibility_polling,
+            perform_typing_action,
+            perform_named_action,
+        ])
+        .plugin(tauri_plugin_opener::init())
+        .plugin(tauri_plugin_macos_permissions::init())
+        .run(tauri::generate_context!())
+        .expect("error while running tauri application");
+}

--- a/screenpipe-vision/src/accessibility_snapshot.swift
+++ b/screenpipe-vision/src/accessibility_snapshot.swift
@@ -1,0 +1,695 @@
+// AccessibilitySnapshot.swift
+// A lightweight Swift library to snapshot the current macOS accessibility hierarchy.
+//
+// This code is intended to be compiled as a dynamic library and called from another language (e.g. Rust).
+// It exports a single C–callable function that returns a JSON string describing all accessible applications' windows
+// and their nested UI elements.
+//
+// To compile (example):
+//   swiftc -emit-library -o libaccessibility.dylib AccessibilitySnapshot.swift
+//
+// Note: The caller is responsible for freeing the returned C string (using free()).
+
+import Cocoa
+import ApplicationServices
+import Foundation
+import CryptoKit
+import CoreSpotlight
+import UniformTypeIdentifiers
+
+// MARK: - Helper: Check Accessibility Permissions
+
+func checkAccessibilityPermissions() -> Bool {
+    // The key kAXTrustedCheckOptionPrompt (bridged) will prompt the user if needed.
+    let promptOption = kAXTrustedCheckOptionPrompt.takeUnretainedValue() as String
+    let options = [promptOption: true] as CFDictionary
+    let trusted = AXIsProcessTrustedWithOptions(options)
+    return trusted
+}
+
+// MARK: - Helper: Get an attribute value
+
+func getAttributeValue(_ element: AXUIElement, attribute: String) -> AnyObject? {
+    var value: AnyObject?
+    let error = AXUIElementCopyAttributeValue(element, attribute as CFString, &value)
+    if error == .success {
+        return value
+    }
+    return nil
+}
+
+// MARK: - Helper: Get Bounding Rect for Selected Text Range
+
+func getBoundingRectForRange(_ element: AXUIElement, range: CFRange) -> CGRect? {
+    // Create an AXValue for the range
+    var rangeValue: AXValue?
+    var rangeCopy = range
+    if let axRange = AXValueCreate(.cfRange, &rangeCopy) {
+        rangeValue = axRange
+    } else {
+        return nil
+    }
+
+    // Get the bounds for the range
+    var result: AnyObject?
+    let error = AXUIElementCopyParameterizedAttributeValue(
+        element,
+        "AXBoundsForRange" as CFString,
+        rangeValue as CFTypeRef,
+        &result
+    )
+
+    if error == .success && result != nil {
+        let rectValue = result as! AXValue
+        var rect = CGRect.zero
+        if AXValueGetValue(rectValue, .cgRect, &rect) {
+            return rect
+        }
+    }
+    return nil
+}
+
+// MARK: - Helper: Describe an attribute value
+
+func describeValue(_ value: AnyObject?) -> String {
+    guard let value = value else { return "" }
+    switch value {
+    case let s as String:
+        return s.replacingOccurrences(of: "\n", with: "\\n")
+    case let n as NSNumber:
+        return n.stringValue
+    case let posVal as AXValue:
+        // Try to interpret as a CGPoint.
+        if AXValueGetType(posVal) == .cgPoint {
+            var point = CGPoint.zero
+            AXValueGetValue(posVal, .cgPoint, &point)
+            return "(\(point.x), \(point.y))"
+        }
+        // Try to interpret as a range
+        if AXValueGetType(posVal) == .cfRange {
+            var range = CFRange()
+            AXValueGetValue(posVal, .cfRange, &range)
+            return "loc=\(range.location) len=\(range.length)"
+        }
+        return "\(posVal)"
+    default:
+        return "\(value)"
+    }
+}
+
+// MARK: - Helper: Check Element Visibility
+
+func isElementVisible(_ element: AXUIElement) -> Bool {
+    // Check explicit visibility attribute
+    if let visible = getAttributeValue(element, attribute: kAXHiddenAttribute as String) as? Bool {
+        return !visible
+    }
+
+    // Check if element has zero size
+    if let sizeAny = getAttributeValue(element, attribute: kAXSizeAttribute as String) {
+        let sizeVal = sizeAny as! AXValue
+        if AXValueGetType(sizeVal) == .cgSize {
+            var size = CGSize.zero
+            AXValueGetValue(sizeVal, .cgSize, &size)
+            if size.width <= 0 || size.height <= 0 {
+                return false
+            }
+        }
+    }
+
+    // Check if element is off-screen
+    if let posAny = getAttributeValue(element, attribute: kAXPositionAttribute as String) {
+        let posVal = posAny as! AXValue
+        if AXValueGetType(posVal) == .cgPoint {
+            var point = CGPoint.zero
+            AXValueGetValue(posVal, .cgPoint, &point)
+            // Basic check if element is way off screen (could be refined based on actual screen bounds)
+            if point.x < -10000 || point.y < -10000 {
+                return false
+            }
+        }
+    }
+
+    // Additional visibility indicators
+    if let shown = getAttributeValue(element, attribute: "AXShownMenu") as? Bool {
+        return shown
+    }
+
+    // Default to visible if no contrary indicators
+    return true
+}
+
+// MARK: - New Helper: Generate an ID from a given accessibility path
+func generateIdFromPath(_ path: String) -> String {
+    let data = Data(path.utf8)
+    let hash = SHA256.hash(data: data)
+    let shortHash = hash.prefix(4)
+    return shortHash.map { String(format: "%02x", $0) }.joined()
+}
+
+// MARK: - New Helper: Recursively find an element with a matching computed id
+func findElementWithId(_ element: AXUIElement, targetId: String, path: String = "") -> AXUIElement? {
+    guard let _ = getAttributeValue(element, attribute: "AXRole") as? String else {
+        return nil
+    }
+
+    let attributesInPath = [
+        "AXRole",
+        "AXRoleDescription",
+        "AXLabel",
+        "AXTitle",
+        "AXDescription",
+        "AXHelp",
+        "AXSubrole"
+    ]
+    let currentAttributesPath = attributesInPath.compactMap { attr -> String? in
+        if let rawVal = getAttributeValue(element, attribute: attr) {
+            let s = describeValue(rawVal)
+            return s.isEmpty ? nil : s
+        }
+        return nil
+    }.joined(separator: " -> ")
+    let currentPath = path.isEmpty ? currentAttributesPath : "\(path) -> \(currentAttributesPath)"
+
+    let computedId = generateIdFromPath(currentPath)
+    if computedId == targetId {
+        return element
+    }
+
+    if let children = getAttributeValue(element, attribute: kAXChildrenAttribute as String) as? [AXUIElement] {
+        for child in children {
+            if let found = findElementWithId(child, targetId: targetId, path: currentPath) {
+                return found
+            }
+        }
+    }
+    return nil
+}
+
+/// Recursively traverses an AXUIElement and returns a dictionary in the "compact" format.
+/// - Parameters:
+///   - element: The accessibility element to traverse.
+///   - depth: The current depth in the tree.
+///   - path: The "path" of parent element roles (used for debugging or identifying the element).
+/// - Returns: A dictionary representing the element (or nil if no useful data was found).
+func traverseElement(_ element: AXUIElement, depth: Int, path: String = "") -> [String: Any]? {
+    // Check visibility first - skip invisible elements
+    if !isElementVisible(element) {
+        return nil
+    }
+
+    // Get the element's role.
+    guard let role = getAttributeValue(element, attribute: "AXRole") as? String else {
+        return nil
+    }
+
+    // Build an updated path using attribute values in order, omitting any empty values.
+    let attributesInPath = [
+        "AXRole",
+        "AXRoleDescription",
+        "AXLabel",
+        "AXTitle",
+        "AXDescription",
+        "AXHelp",
+        "AXSubrole"
+    ]
+    let currentAttributesPath = attributesInPath.compactMap { attr -> String? in
+        if let rawVal = getAttributeValue(element, attribute: attr) {
+            let s = describeValue(rawVal)
+            return s.isEmpty ? nil : s
+        }
+        return nil
+    }.joined(separator: " -> ")
+    let currentPath = path.isEmpty ? currentAttributesPath : "\(path) -> \(currentAttributesPath)"
+
+    // Compute the unique id from the path.
+    let computedId = generateIdFromPath(currentPath)
+
+    // Create the element dictionary.
+    var dict: [String: Any] = [:]
+    dict["id"] = computedId         // Unique identifier
+    dict["e"] = role                // Element type (role)
+    dict["p"] = currentPath         // Unique path / identifier
+    dict["d"] = depth               // Depth (an integer)
+
+    // Get frame information: position and size.
+    var frame: [CGFloat] = [0, 0, 0, 0]
+
+    if let posAny = getAttributeValue(element, attribute: kAXPositionAttribute as String) {
+        let posVal = posAny as! AXValue
+        if AXValueGetType(posVal) == .cgPoint {
+            var point = CGPoint.zero
+            AXValueGetValue(posVal, .cgPoint, &point)
+            frame[0] = point.x
+            frame[1] = point.y
+        }
+    }
+
+    if let sizeAny = getAttributeValue(element, attribute: kAXSizeAttribute as String) {
+        let sizeVal = sizeAny as! AXValue
+        if AXValueGetType(sizeVal) == .cgSize {
+            var size = CGSize.zero
+            AXValueGetValue(sizeVal, .cgSize, &size)
+            frame[2] = size.width
+            frame[3] = size.height
+        }
+    }
+    dict["f"] = frame
+
+    // Capture a few useful attributes.
+    var attributes: [String: String] = [:]
+    let attributesToCheck = [
+        "AXRole",
+        "AXRoleDescription",
+        "AXValue",
+        "AXLabel",
+        "AXTitle",
+        "AXDescription",
+        "AXHelp",
+        "AXSelected",
+        "AXEnabled",
+        "AXFocused",
+        "AXSubrole"
+    ]
+    for attr in attributesToCheck {
+        if let raw = getAttributeValue(element, attribute: attr) {
+            let s = describeValue(raw)
+            if !s.isEmpty {
+                attributes[attr] = s
+            }
+        }
+    }
+
+    // Add text-specific attributes for text elements
+    if role == "AXTextArea" || role == "AXTextField" {
+        // Get selected text range
+        if let selectedRange = getAttributeValue(element, attribute: "AXSelectedTextRange") {
+            let axValue = selectedRange as! AXValue
+            if AXValueGetType(axValue) == .cfRange {
+                var range = CFRange()
+                AXValueGetValue(axValue, .cfRange, &range)
+                attributes["AXSelectedTextRange"] = describeValue(selectedRange)
+
+                // Get bounding rect for selected text if there is a selection
+                if range.length > 0 {
+                    if let rect = getBoundingRectForRange(element, range: range) {
+                        attributes["AXSelectedTextBounds"] = String(format: "%.1f,%.1f,%.1f,%.1f",
+                            rect.origin.x, rect.origin.y, rect.size.width, rect.size.height)
+                    }
+                }
+            }
+        }
+
+        // Get selected text
+        if let selectedText = getAttributeValue(element, attribute: "AXSelectedText") {
+            attributes["AXSelectedText"] = describeValue(selectedText)
+        }
+
+        // Get marked text range
+        if let markedRange = getAttributeValue(element, attribute: "AXMarkedTextRange") {
+            attributes["AXMarkedTextRange"] = describeValue(markedRange)
+        }
+
+        // Get number of characters
+        if let numberOfCharacters = getAttributeValue(element, attribute: "AXNumberOfCharacters") {
+            attributes["AXNumberOfCharacters"] = describeValue(numberOfCharacters)
+        }
+
+        // Get placeholder value
+        if let placeholder = getAttributeValue(element, attribute: "AXPlaceholderValue") {
+            attributes["AXPlaceholderValue"] = describeValue(placeholder)
+        }
+    }
+
+    if !attributes.isEmpty {
+        dict["a"] = attributes
+    }
+
+    // Capture available actions (methods) on the element.
+    var actions: [String] = []
+    var actionNames: CFArray?
+    if AXUIElementCopyActionNames(element, &actionNames) == .success,
+       let actionArray = actionNames as? [String] {
+        actions = actionArray
+    }
+    if !actions.isEmpty {
+        dict["m"] = actions
+    }
+
+    // Recurse into the children.
+    var childrenArray: [[String: Any]] = []
+    if let children = getAttributeValue(element, attribute: kAXChildrenAttribute as String) as? [AXUIElement] {
+        for child in children {
+            if let childDict = traverseElement(child, depth: depth + 1, path: currentPath) {
+                childrenArray.append(childDict)
+            }
+        }
+    }
+    if !childrenArray.isEmpty {
+        dict["c"] = childrenArray
+    }
+
+    return dict
+}
+
+// MARK: - Main Snapshot Function
+
+// Add these new types at the top of the file
+struct SnapshotFilter {
+    let appName: String?
+    let windowTitle: String?
+}
+
+/// Gathers the current accessibility hierarchy, optionally filtered by app and window
+/// - Parameters:
+///   - filter: Optional filter criteria for app name and window title
+/// - Returns: A JSON string with the snapshot, or an error JSON if permissions are missing.
+func snapshotAccessibilityHierarchy(filter: SnapshotFilter? = nil) -> String {
+    guard checkAccessibilityPermissions() else {
+        return "{\"error\": \"Accessibility permissions not granted\"}"
+    }
+
+    // The final JSON structure.
+    var result: [String: Any] = [:]
+    result["ts"] = ISO8601DateFormatter().string(from: Date())
+
+    // This will contain the UI elements (each representing a window)
+    var elements: [[String: Any]] = []
+
+    // Get all running (regular) applications
+    let runningApps = NSWorkspace.shared.runningApplications.filter { app in
+        guard app.activationPolicy == .regular else { return false }
+
+        // If we have a filter, check the app name
+        if let filter = filter, let filterAppName = filter.appName {
+            guard let appName = app.localizedName else { return false }
+            return appName.lowercased() == filterAppName.lowercased()
+        }
+
+        // If no filter or app name doesn't match filter, check if app is active
+        return app.isActive
+    }
+
+    for app in runningApps {
+        guard let appName = app.localizedName else { continue }
+        let axApp = AXUIElementCreateApplication(app.processIdentifier)
+
+        // Check if the application is active (frontmost)
+        let isAppActive = app.isActive
+
+        if let windows = getAttributeValue(axApp, attribute: kAXWindowsAttribute as String) as? [AXUIElement] {
+            for window in windows {
+                // Check window title against filter if provided
+                if let filter = filter, let filterWindowTitle = filter.windowTitle {
+                    guard let windowTitle = getAttributeValue(window, attribute: kAXTitleAttribute as String) as? String,
+                          windowTitle.lowercased() == filterWindowTitle.lowercased() else {
+                        continue
+                    }
+                }
+
+                // Check if this window is the main window
+                if let main = getAttributeValue(window, attribute: kAXMainAttribute as String) as? Bool, main {
+                    // Traverse the window's UI tree.
+                    if var windowDict = traverseElement(window, depth: 0) {
+                        windowDict["main"] = main
+
+                        // Optionally include the application name.
+                        windowDict["app"] = appName
+                        // Include whether the application is active
+                        windowDict["appActive"] = isAppActive
+
+                        // Check if this window is focused
+                        // if let focused = getAttributeValue(window, attribute: kAXFocusedAttribute as String) as? Bool {
+                        //     windowDict["focused"] = focused
+                        // }
+                        elements.append(windowDict)
+                    }
+                }
+            }
+        }
+    }
+
+    result["e"] = elements
+
+    // Serialize the result to JSON.
+    if let data = try? JSONSerialization.data(withJSONObject: result, options: []),
+       let jsonString = String(data: data, encoding: .utf8) {
+        return jsonString
+    }
+
+    return "{}"
+}
+
+/// C-callable function to get the accessibility hierarchy with optional filtering
+@_cdecl("get_accessibility_hierarchy_filtered")
+public func get_accessibility_hierarchy_filtered(
+    appName: UnsafePointer<CChar>?,
+    windowTitle: UnsafePointer<CChar>?
+) -> UnsafeMutablePointer<CChar>? {
+    let filter: SnapshotFilter?
+
+    if let appName = appName, let windowTitle = windowTitle {
+        filter = SnapshotFilter(
+            appName: String(cString: appName),
+            windowTitle: String(cString: windowTitle)
+        )
+    } else if let appName = appName {
+        filter = SnapshotFilter(
+            appName: String(cString: appName),
+            windowTitle: nil
+        )
+    } else if let windowTitle = windowTitle {
+        filter = SnapshotFilter(
+            appName: nil,
+            windowTitle: String(cString: windowTitle)
+        )
+    } else {
+        filter = nil
+    }
+
+    let jsonString = snapshotAccessibilityHierarchy(filter: filter)
+    return strdup(jsonString)
+}
+
+// Keep the original unfiltered function for backward compatibility
+@_cdecl("get_accessibility_hierarchy")
+public func get_accessibility_hierarchy() -> UnsafeMutablePointer<CChar>? {
+    let jsonString = snapshotAccessibilityHierarchy(filter: nil)
+    return strdup(jsonString)
+}
+
+// New helper: Recursively find an element with specific role and title
+func findElementWithRoleAndTitle(_ element: AXUIElement, role: String, title: String) -> AXUIElement? {
+    if let elementRole = getAttributeValue(element, attribute: "AXRole") as? String,
+       elementRole == role {
+        if let elementTitle = getAttributeValue(element, attribute: "AXTitle") as? String,
+           elementTitle == title {
+            return element
+        }
+        if let elementLabel = getAttributeValue(element, attribute: "AXLabel") as? String,
+           elementLabel == title {
+            return element
+        }
+        if let elementDescription = getAttributeValue(element, attribute: "AXDescription") as? String,
+           elementDescription == title {
+            return element
+        }
+    }
+    if let children = getAttributeValue(element, attribute: kAXChildrenAttribute as String) as? [AXUIElement] {
+        for child in children {
+            if let found = findElementWithRoleAndTitle(child, role: role, title: title) {
+                return found
+            }
+        }
+    }
+    return nil
+}
+
+@_cdecl("perform_type_action")
+public func perform_type_action(cElementId: UnsafePointer<CChar>, cText: UnsafePointer<CChar>) -> UnsafeMutablePointer<CChar>? {
+    let windowTitle = "Skip - Google Chrome" // TODO: Implement dynamic window searching later
+    let elementId = String(cString: cElementId)
+    let newText = String(cString: cText)
+
+    print("perform_type_action received elementId: \(elementId), newText: \(newText)")
+    guard checkAccessibilityPermissions() else {
+        print("Accessibility permissions not granted")
+        return strdup("Accessibility permissions not granted")
+    }
+    let window: AXUIElement?
+    if let foundWindow = findWindowWithTitle(windowTitle) {
+        window = foundWindow
+        print("Found window with title: \(windowTitle)")
+    } else {
+        window = getFrontmostWindow()
+        print("Using frontmost window as fallback")
+    }
+    if let window = window {
+        if let textField = findElementWithId(window, targetId: elementId) {
+            print("Found text field with id: \(elementId)")
+
+            // Check if element has AXPress action
+            var actionNames: CFArray?
+            if AXUIElementCopyActionNames(textField, &actionNames) == .success,
+               let actionArray = actionNames as? [String],
+               actionArray.contains("AXPress") {
+                // Perform AXPress action
+                print("Found AXPress action, performing it first")
+                let pressError = AXUIElementPerformAction(textField, "AXPress" as CFString)
+                if pressError == .success {
+                    print("Successfully performed AXPress action")
+                } else {
+                    print("Failed to perform AXPress action: \(pressError)")
+                }
+                // Wait 20 milliseconds
+                usleep(20_000)
+            }
+
+            // Read the initial value (before) from the text field
+            var currentValueBefore: AnyObject?
+            let readErrorBefore = AXUIElementCopyAttributeValue(textField, kAXValueAttribute as CFString, &currentValueBefore)
+            var beforeText = ""
+            if readErrorBefore == .success, let valueBefore = currentValueBefore {
+                let valueCF = valueBefore as! CFString
+                beforeText = valueCF as String
+            } else {
+                beforeText = "Error reading initial value"
+            }
+
+            // Set the new text
+            let cfText = newText as CFString
+            let error = AXUIElementSetAttributeValue(textField, kAXValueAttribute as CFString, cfText)
+            if error == .success {
+                print("Successfully set text for element with id \(elementId)")
+            } else {
+                print("Failed to set text, error: \(error)")
+            }
+            // Wait 0.1 second
+            usleep(100_000)
+            // Read back the updated (after) value
+            var currentValue: AnyObject?
+            let readError = AXUIElementCopyAttributeValue(textField, kAXValueAttribute as CFString, &currentValue)
+            var afterText = ""
+            if readError == .success, let value = currentValue {
+                let valueCF = value as! CFString
+                afterText = valueCF as String
+                print("Read latest text from element \(elementId): \(afterText)")
+            } else {
+                afterText = "Error reading latest value"
+                print("Failed to read latest value for element \(elementId), error: \(readError)")
+            }
+            // Return a JSON string with both before and after values
+            let resultDict = ["before": beforeText, "after": afterText]
+            if let jsonData = try? JSONSerialization.data(withJSONObject: resultDict, options: []),
+               let jsonString = String(data: jsonData, encoding: .utf8) {
+                return strdup(jsonString)
+            }
+            return strdup("{\"before\": \"\", \"after\": \"\"}")
+        } else {
+            print("No element with id \(elementId) found in window")
+            return strdup("Error: Element not found in window")
+        }
+    } else {
+        print("No window found")
+        return strdup("Error: Window not found")
+    }
+    // Fallback
+    print("No element with id \(elementId) found in any window")
+    return strdup("Error: Element not found in any window")
+}
+
+func getFrontmostWindow() -> AXUIElement? {
+    // Get the frontmost application
+    guard let frontmostApp = NSWorkspace.shared.frontmostApplication else {
+        print("No frontmost application found")
+        return nil
+    }
+
+    // Create an AXUIElement for the frontmost application
+    let axApp = AXUIElementCreateApplication(frontmostApp.processIdentifier)
+
+    // Try to get the frontmost window for this app
+    if let windows = getAttributeValue(axApp, attribute: kAXWindowsAttribute as String) as? [AXUIElement] {
+        for window in windows {
+            if let isMainWindow = getAttributeValue(window, attribute: kAXMainAttribute as String) as? Bool, isMainWindow {
+                return window
+            }
+        }
+    }
+
+    print("No frontmost window found for application \(frontmostApp.localizedName ?? "Unknown")")
+    return nil
+}
+
+
+func findWindowWithTitle(_ title: String) -> AXUIElement? {
+    print("findWindowWithTitle: \(title)")
+
+    // Get all running (regular) applications.
+    let runningApps = NSWorkspace.shared.runningApplications.filter { $0.activationPolicy == .regular }
+    for app in runningApps {
+        // Check that localizedName exists; we don't need the value here
+        if app.localizedName == nil { continue }
+        let axApp = AXUIElementCreateApplication(app.processIdentifier)
+
+        // Try to get the windows for this app.
+        if let windows = getAttributeValue(axApp, attribute: kAXWindowsAttribute as String) as? [AXUIElement] {
+            for window in windows {
+                if let windowTitle = getAttributeValue(window, attribute: kAXTitleAttribute as String) as? String {
+                    print("Window title: \"\(windowTitle)\"")
+                    if windowTitle.contains(title) {
+                        return window
+                    }
+                }
+            }
+        }
+    }
+    return nil
+}
+
+@_cdecl("perform_named_action")
+public func perform_named_action(cElementId: UnsafePointer<CChar>, cActionName: UnsafePointer<CChar>) -> UnsafeMutablePointer<CChar>? {
+    let windowTitle = "Skip - Google Chrome" // TODO: Implement dynamic window searching later
+    let elementId = String(cString: cElementId)
+    let actionName = String(cString: cActionName)
+
+    print("perform_named_action received elementId: \(elementId), actionName: \(actionName)")
+
+    guard checkAccessibilityPermissions() else {
+        print("Accessibility permissions not granted")
+        return strdup("Accessibility permissions not granted")
+    }
+
+    let window: AXUIElement?
+    if let foundWindow = findWindowWithTitle(windowTitle) {
+        window = foundWindow
+        print("Found window with title: \(windowTitle)")
+    } else {
+        window = getFrontmostWindow()
+        print("Using frontmost window as fallback")
+    }
+
+    if let window = window {
+        if let element = findElementWithId(window, targetId: elementId) {
+            print("Found element with id: \(elementId)")
+
+            let error = AXUIElementPerformAction(element, actionName as CFString)
+            if error == .success {
+                print("Successfully performed action \(actionName) on element \(elementId)")
+                return strdup("{\"result\": \"success\"}")
+            } else {
+                print("Failed to perform action: \(error)")
+                return strdup("Error: Failed to perform action")
+            }
+        } else {
+            print("No element with id \(elementId) found in window")
+            return strdup("Error: Element not found in window")
+        }
+    } else {
+        print("No window found")
+        return strdup("Error: Window not found")
+    }
+
+    print("No element with id \(elementId) found in any window")
+    return strdup("Error: Element not found in any window")
+}


### PR DESCRIPTION
This commit introduces a comprehensive accessibility snapshot and interaction library for macOS, with two key components:

- Rust module (`accessibility_snapshot.rs`) for managing UI element retrieval and interaction
- Swift module (`accessibility_snapshot.swift`) providing low-level accessibility hierarchy parsing and element manipulation

Key features include:
- Snapshot UI elements with detailed metadata
- Perform typing and named actions on UI elements
- Support for filtering snapshots by app and window
- Robust error handling and permission checks

---
name: pull request
about: submit changes to the project
title: "[pr] "
labels: ''
assignees: ''

---

Hey Matt! Here's my WIP code which could be included screenpipe!
I removed my app specific stuff, so this should be applicable to specifically screenpipe.

## What my AI automation app needs:

1. Ability to get real-time (~500 ms) updates for changes. On the client side have a complete copy (not diff), however, implementation detail may be that screenpipe server sends diffs and screenpipe SDK
2. Export includes: nested hierarchy of elements, each element with a unique and stable ID (currently creating by short-hashing their path & a few attributes), bbox of element (x,y, width, height), actions available (if an input or interactive type element), values and text selection ranges (if applicable).
3. Able to access in both Tauri Rust apps and the web client side. I need to perform stuff quickly in Rust side to show certain UI elements specific to my app, so screenpipe<>my Rust app needs to be possib
le and fast for round trip.

## TODOs/Known Issues

- Getting the UI elements for a single window is relatively fast, often ~50 ms. However, updating ALL apps and windows (I have too many Chrome tabs 😝 ) is wasteful and slow. So currently I only update the active window, ideally all windows should be updated.
- No observers/events to detect changes and trigger update of UI, only simple polling. screenpipe has ability to detect when and send diffs currently which is better.

---

## Example

![image](https://github.com/user-attachments/assets/5a32dd1f-c870-4b63-82d8-e7eb7693d90c)

### Actions:

```
AXRaise: 1 elements (49b53b35)
AXScrollLeftByPage: 1 elements (7673b8aa)
AXScrollRightByPage: 1 elements (7673b8aa)
AXScrollUpByPage: 1 elements (7673b8aa)
AXScrollDownByPage: 1 elements (7673b8aa)
AXPress: 21 elements (f9f0aa47, 223bf4f3, 8705d380, aea8075d, 10133bd2, 70821c30, 77c23b88, c3b236e7, 42b8b48f, 7aee7e2e, f4e138b2, baff4bff, 1494f6e2, 3cc102b6, 50c19bb7, 8bb8d4e8, 673516c6, c6e9fa93, b06936cd, 9ca0e5d3, 6f8868da)
AXDelete: 15 elements (cc3df940, cc3df940, cc3df940, cc3df940, cc3df940, cc3df940, cc3df940, cc3df940, cc3df940, cc3df940, cc3df940, cc3df940, cc3df940, cc3df940, cc3df940)
AXConfirm: 1 elements (ef6e0016)
AXZoomWindow: 1 elements (b06936cd)
```

Not including typing actions, which are applicable for elements like `AXTextField`.

### UI elements:

```json
{
  "e": [
    {
      "a": {
        "AXFocused": "0",
        "AXRole": "AXWindow",
        "AXRoleDescription": "standard window",
        "AXSubrole": "AXStandardWindow",
        "AXTitle": "Untitled 4.rtf"
      },
      "app": "TextEdit",
      "appActive": true,
      "c": [
        {
          "a": {
            "AXFocused": "0",
            "AXRole": "AXScrollArea",
            "AXRoleDescription": "scroll area"
          },
          "c": [
            {
              "a": {
                "AXFocused": "1",
                "AXNumberOfCharacters": "39",
                "AXRole": "AXTextArea",
                "AXRoleDescription": "text entry area",
                "AXSelectedText": "jumps",
                "AXSelectedTextBounds": "3174.4,561.0,32.0,14.0",
                "AXSelectedTextRange": "loc=14 len=5",
                "AXValue": "The brown fox jumps over the lazy dog.\\n"
              },
              "d": 2,
              "e": "AXTextArea",
              "f": [
                3090,
                561,
                586,
                388
              ],
              "id": "dc128576",
              "m": [
                "AXShowMenu"
              ],
              "p": "AXWindow -> standard window -> Untitled 4.rtf -> AXStandardWindow -> AXScrollArea -> scroll area -> AXTextArea -> text entry area"
            },
            {
              "a": {
                "AXFocused": "0",
                "AXRole": "AXRuler",
                "AXRoleDescription": "ruler"
              },
              "c": [
                {
                  "a": {
                    "AXRole": "AXRulerMarker",
                    "AXRoleDescription": "ruler marker",
                    "AXValue": "0"
                  },
                  "d": 3,
                  "e": "AXRulerMarker",
                  "f": [
                    3091,
                    538,
                    9,
                    6
                  ],
                  "id": "cc3df940",
                  "m": [
                    "AXDelete"
                  ],
                  "p": "AXWindow -> standard window -> Untitled 4.rtf -> AXStandardWindow -> AXScrollArea -> scroll area -> AXRuler -> ruler -> AXRulerMarker -> ruler marker"
                },
                {
                  "a": {
                    "AXRole": "AXRulerMarker",
                    "AXRoleDescription": "ruler marker",
                    "AXValue": "20.31746031746032"
                  },
                  "d": 3,
                  "e": "AXRulerMarker",
                  "f": [
                    3667,
                    538,
                    9,
                    6
                  ],
                  "id": "cc3df940",
                  "m": [
                    "AXDelete"
                  ],
                  "p": "AXWindow -> standard window -> Untitled 4.rtf -> AXStandardWindow -> AXScrollArea -> scroll area -> AXRuler -> ruler -> AXRulerMarker -> ruler marker"
                },
                {
                  "a": {
                    "AXRole": "AXRulerMarker",
                    "AXRoleDescription": "ruler marker",
                    "AXValue": "0"
                  },
                  "d": 3,
                  "e": "AXRulerMarker",
                  "f": [
                    3091,
                    534,
                    9,
                    10
                  ],
                  "id": "cc3df940",
                  "m": [
                    "AXDelete"
                  ],
                  "p": "AXWindow -> standard window -> Untitled 4.rtf -> AXStandardWindow -> AXScrollArea -> scroll area -> AXRuler -> ruler -> AXRulerMarker -> ruler marker"
                },
                {
                  "a": {
                    "AXRole": "AXRulerMarker",
                    "AXRoleDescription": "ruler marker",
                    "AXValue": "1.26984126984127"
                  },
                  "d": 3,
                  "e": "AXRulerMarker",
                  "f": [
                    3131,
                    535,
                    6,
                    9
                  ],
                  "id": "cc3df940",
                  "m": [
                    "AXDelete"
                  ],
                  "p": "AXWindow -> standard window -> Untitled 4.rtf -> AXStandardWindow -> AXScrollArea -> scroll area -> AXRuler -> ruler -> AXRulerMarker -> ruler marker"
                },
                {
                  "a": {
                    "AXRole": "AXRulerMarker",
                    "AXRoleDescription": "ruler marker",
                    "AXValue": "2.53968253968254"
                  },
                  "d": 3,
                  "e": "AXRulerMarker",
                  "f": [
                    3167,
                    535,
                    6,
                    9
                  ],
                  "id": "cc3df940",
                  "m": [
                    "AXDelete"
                  ],
                  "p": "AXWindow -> standard window -> Untitled 4.rtf -> AXStandardWindow -> AXScrollArea -> scroll area -> AXRuler -> ruler -> AXRulerMarker -> ruler marker"
                },
                {
                  "a": {
                    "AXRole": "AXRulerMarker",
                    "AXRoleDescription": "ruler marker",
                    "AXValue": "3.809523809523809"
                  },
                  "d": 3,
                  "e": "AXRulerMarker",
                  "f": [
                    3203,
                    535,
                    6,
                    9
                  ],
                  "id": "cc3df940",
                  "m": [
                    "AXDelete"
                  ],
                  "p": "AXWindow -> standard window -> Untitled 4.rtf -> AXStandardWindow -> AXScrollArea -> scroll area -> AXRuler -> ruler -> AXRulerMarker -> ruler marker"
                },
                {
                  "a": {
                    "AXRole": "AXRulerMarker",
                    "AXRoleDescription": "ruler marker",
                    "AXValue": "5.079365079365079"
                  },
                  "d": 3,
                  "e": "AXRulerMarker",
                  "f": [
                    3239,
                    535,
                    6,
                    9
                  ],
                  "id": "cc3df940",
                  "m": [
                    "AXDelete"
                  ],
                  "p": "AXWindow -> standard window -> Untitled 4.rtf -> AXStandardWindow -> AXScrollArea -> scroll area -> AXRuler -> ruler -> AXRulerMarker -> ruler marker"
                },
                {
                  "a": {
                    "AXRole": "AXRulerMarker",
                    "AXRoleDescription": "ruler marker",
                    "AXValue": "6.349206349206349"
                  },
                  "d": 3,
                  "e": "AXRulerMarker",
                  "f": [
                    3275,
                    535,
                    6,
                    9
                  ],
                  "id": "cc3df940",
                  "m": [
                    "AXDelete"
                  ],
                  "p": "AXWindow -> standard window -> Untitled 4.rtf -> AXStandardWindow -> AXScrollArea -> scroll area -> AXRuler -> ruler -> AXRulerMarker -> ruler marker"
                },
                {
                  "a": {
                    "AXRole": "AXRulerMarker",
                    "AXRoleDescription": "ruler marker",
                    "AXValue": "7.619047619047619"
                  },
                  "d": 3,
                  "e": "AXRulerMarker",
                  "f": [
                    3311,
                    535,
                    6,
                    9
                  ],
                  "id": "cc3df940",
                  "m": [
                    "AXDelete"
                  ],
                  "p": "AXWindow -> standard window -> Untitled 4.rtf -> AXStandardWindow -> AXScrollArea -> scroll area -> AXRuler -> ruler -> AXRulerMarker -> ruler marker"
                },
                {
                  "a": {
                    "AXRole": "AXRulerMarker",
                    "AXRoleDescription": "ruler marker",
                    "AXValue": "8.888888888888889"
                  },
                  "d": 3,
                  "e": "AXRulerMarker",
                  "f": [
                    3347,
                    535,
                    6,
                    9
                  ],
                  "id": "cc3df940",
                  "m": [
                    "AXDelete"
                  ],
                  "p": "AXWindow -> standard window -> Untitled 4.rtf -> AXStandardWindow -> AXScrollArea -> scroll area -> AXRuler -> ruler -> AXRulerMarker -> ruler marker"
                },
                {
                  "a": {
                    "AXRole": "AXRulerMarker",
                    "AXRoleDescription": "ruler marker",
                    "AXValue": "10.15873015873016"
                  },
                  "d": 3,
                  "e": "AXRulerMarker",
                  "f": [
                    3383,
                    535,
                    6,
                    9
                  ],
                  "id": "cc3df940",
                  "m": [
                    "AXDelete"
                  ],
                  "p": "AXWindow -> standard window -> Untitled 4.rtf -> AXStandardWindow -> AXScrollArea -> scroll area -> AXRuler -> ruler -> AXRulerMarker -> ruler marker"
                },
                {
                  "a": {
                    "AXRole": "AXRulerMarker",
                    "AXRoleDescription": "ruler marker",
                    "AXValue": "11.42857142857143"
                  },
                  "d": 3,
                  "e": "AXRulerMarker",
                  "f": [
                    3419,
                    535,
                    6,
                    9
                  ],
                  "id": "cc3df940",
                  "m": [
                    "AXDelete"
                  ],
                  "p": "AXWindow -> standard window -> Untitled 4.rtf -> AXStandardWindow -> AXScrollArea -> scroll area -> AXRuler -> ruler -> AXRulerMarker -> ruler marker"
                },
                {
                  "a": {
                    "AXRole": "AXRulerMarker",
                    "AXRoleDescription": "ruler marker",
                    "AXValue": "12.6984126984127"
                  },
                  "d": 3,
                  "e": "AXRulerMarker",
                  "f": [
                    3455,
                    535,
                    6,
                    9
                  ],
                  "id": "cc3df940",
                  "m": [
                    "AXDelete"
                  ],
                  "p": "AXWindow -> standard window -> Untitled 4.rtf -> AXStandardWindow -> AXScrollArea -> scroll area -> AXRuler -> ruler -> AXRulerMarker -> ruler marker"
                },
                {
                  "a": {
                    "AXRole": "AXRulerMarker",
                    "AXRoleDescription": "ruler marker",
                    "AXValue": "13.96825396825397"
                  },
                  "d": 3,
                  "e": "AXRulerMarker",
                  "f": [
                    3491,
                    535,
                    6,
                    9
                  ],
                  "id": "cc3df940",
                  "m": [
                    "AXDelete"
                  ],
                  "p": "AXWindow -> standard window -> Untitled 4.rtf -> AXStandardWindow -> AXScrollArea -> scroll area -> AXRuler -> ruler -> AXRulerMarker -> ruler marker"
                },
                {
                  "a": {
                    "AXRole": "AXRulerMarker",
                    "AXRoleDescription": "ruler marker",
                    "AXValue": "15.23809523809524"
                  },
                  "d": 3,
                  "e": "AXRulerMarker",
                  "f": [
                    3527,
                    535,
                    6,
                    9
                  ],
                  "id": "cc3df940",
                  "m": [
                    "AXDelete"
                  ],
                  "p": "AXWindow -> standard window -> Untitled 4.rtf -> AXStandardWindow -> AXScrollArea -> scroll area -> AXRuler -> ruler -> AXRulerMarker -> ruler marker"
                }
              ],
              "d": 2,
              "e": "AXRuler",
              "f": [
                3090,
                529,
                586,
                32
              ],
              "id": "f9f0aa47",
              "m": [
                "AXPress"
              ],
              "p": "AXWindow -> standard window -> Untitled 4.rtf -> AXStandardWindow -> AXScrollArea -> scroll area -> AXRuler -> ruler"
            }
          ],
          "d": 1,
          "e": "AXScrollArea",
          "f": [
            3090,
            529,
            586,
            420
          ],
          "id": "7673b8aa",
          "m": [
            "AXScrollLeftByPage",
            "AXScrollRightByPage",
            "AXScrollUpByPage",
            "AXScrollDownByPage"
          ],
          "p": "AXWindow -> standard window -> Untitled 4.rtf -> AXStandardWindow -> AXScrollArea -> scroll area"
        },
        {
          "a": {
            "AXFocused": "0",
            "AXRole": "AXToolbar",
            "AXRoleDescription": "toolbar"
          },
          "c": [
            {
              "a": {
                "AXDescription": "typeface",
                "AXEnabled": "1",
                "AXFocused": "0",
                "AXHelp": "Choose the typeface",
                "AXRole": "AXPopUpButton",
                "AXRoleDescription": "pop up button",
                "AXValue": "Helvetica"
              },
              "d": 2,
              "e": "AXPopUpButton",
              "f": [
                3097,
                505,
                100,
                21
              ],
              "id": "223bf4f3",
              "m": [
                "AXShowMenu",
                "AXPress"
              ],
              "p": "AXWindow -> standard window -> Untitled 4.rtf -> AXStandardWindow -> AXToolbar -> toolbar -> AXPopUpButton -> pop up button -> typeface -> Choose the typeface"
            },
            {
              "a": {
                "AXDescription": "style",
                "AXEnabled": "1",
                "AXFocused": "0",
                "AXHelp": "Choose the style",
                "AXRole": "AXPopUpButton",
                "AXRoleDescription": "pop up button",
                "AXValue": "Regular"
              },
              "d": 2,
              "e": "AXPopUpButton",
              "f": [
                3202,
                505,
                100,
                21
              ],
              "id": "8705d380",
              "m": [
                "AXShowMenu",
                "AXPress"
              ],
              "p": "AXWindow -> standard window -> Untitled 4.rtf -> AXStandardWindow -> AXToolbar -> toolbar -> AXPopUpButton -> pop up button -> style -> Choose the style"
            },
            {
              "a": {
                "AXDescription": "font size",
                "AXEnabled": "1",
                "AXFocused": "0",
                "AXHelp": "Set the font size",
                "AXRole": "AXComboBox",
                "AXRoleDescription": "combo box",
                "AXValue": "12"
              },
              "c": [
                {
                  "a": {
                    "AXEnabled": "1",
                    "AXFocused": "0",
                    "AXRole": "AXButton",
                    "AXRoleDescription": "button"
                  },
                  "d": 3,
                  "e": "AXButton",
                  "f": [
                    3333,
                    505,
                    21,
                    21
                  ],
                  "id": "aea8075d",
                  "m": [
                    "AXPress"
                  ],
                  "p": "AXWindow -> standard window -> Untitled 4.rtf -> AXStandardWindow -> AXToolbar -> toolbar -> AXComboBox -> combo box -> font size -> Set the font size -> AXButton -> button"
                }
              ],
              "d": 2,
              "e": "AXComboBox",
              "f": [
                3307,
                505,
                45,
                21
              ],
              "id": "ef6e0016",
              "m": [
                "AXShowMenu",
                "AXConfirm"
              ],
              "p": "AXWindow -> standard window -> Untitled 4.rtf -> AXStandardWindow -> AXToolbar -> toolbar -> AXComboBox -> combo box -> font size -> Set the font size"
            },
            {
              "a": {
                "AXDescription": "text color",
                "AXEnabled": "1",
                "AXFocused": "0",
                "AXHelp": "Click to choose the text color",
                "AXRole": "AXColorWell",
                "AXRoleDescription": "color well",
                "AXValue": "rgb 1 1 1 1"
              },
              "c": [
                {
                  "a": {
                    "AXEnabled": "1",
                    "AXFocused": "0",
                    "AXRole": "AXButton",
                    "AXRoleDescription": "button"
                  },
                  "d": 3,
                  "e": "AXButton",
                  "f": [
                    3359,
                    505,
                    22,
                    21
                  ],
                  "id": "70821c30",
                  "m": [
                    "AXPress"
                  ],
                  "p": "AXWindow -> standard window -> Untitled 4.rtf -> AXStandardWindow -> AXToolbar -> toolbar -> AXColorWell -> color well -> text color -> Click to choose the text color -> AXButton -> button"
                }
              ],
              "d": 2,
              "e": "AXColorWell",
              "f": [
                3359,
                505,
                22,
                21
              ],
              "id": "10133bd2",
              "m": [
                "AXPress"
              ],
              "p": "AXWindow -> standard window -> Untitled 4.rtf -> AXStandardWindow -> AXToolbar -> toolbar -> AXColorWell -> color well -> text color -> Click to choose the text color"
            },
            {
              "a": {
                "AXDescription": "text background color",
                "AXEnabled": "1",
                "AXFocused": "0",
                "AXHelp": "Click to choose the text background color",
                "AXRole": "AXColorWell",
                "AXRoleDescription": "color well",
                "AXValue": "rgb 0 0 0 0"
              },
              "c": [
                {
                  "a": {
                    "AXEnabled": "1",
                    "AXFocused": "0",
                    "AXRole": "AXButton",
                    "AXRoleDescription": "button"
                  },
                  "d": 3,
                  "e": "AXButton",
                  "f": [
                    3386,
                    505,
                    22,
                    21
                  ],
                  "id": "c3b236e7",
                  "m": [
                    "AXPress"
                  ],
                  "p": "AXWindow -> standard window -> Untitled 4.rtf -> AXStandardWindow -> AXToolbar -> toolbar -> AXColorWell -> color well -> text background color -> Click to choose the text background color -> AXButton -> button"
                }
              ],
              "d": 2,
              "e": "AXColorWell",
              "f": [
                3386,
                505,
                22,
                21
              ],
              "id": "77c23b88",
              "m": [
                "AXPress"
              ],
              "p": "AXWindow -> standard window -> Untitled 4.rtf -> AXStandardWindow -> AXToolbar -> toolbar -> AXColorWell -> color well -> text background color -> Click to choose the text background color"
            },
            {
              "a": {
                "AXDescription": "text style",
                "AXEnabled": "1",
                "AXFocused": "0",
                "AXRole": "AXGroup",
                "AXRoleDescription": "group"
              },
              "c": [
                {
                  "a": {
                    "AXDescription": "bold",
                    "AXEnabled": "1",
                    "AXFocused": "0",
                    "AXHelp": "Bold text",
                    "AXRole": "AXCheckBox",
                    "AXRoleDescription": "checkbox",
                    "AXSubrole": "AXSegment",
                    "AXValue": "0"
                  },
                  "d": 3,
                  "e": "AXCheckBox",
                  "f": [
                    3415,
                    505,
                    22,
                    21
                  ],
                  "id": "42b8b48f",
                  "m": [
                    "AXPress"
                  ],
                  "p": "AXWindow -> standard window -> Untitled 4.rtf -> AXStandardWindow -> AXToolbar -> toolbar -> AXGroup -> group -> text style -> AXCheckBox -> checkbox -> bold -> Bold text -> AXSegment"
                },
                {
                  "a": {
                    "AXDescription": "italic",
                    "AXEnabled": "1",
                    "AXFocused": "0",
                    "AXHelp": "Italicize text",
                    "AXRole": "AXCheckBox",
                    "AXRoleDescription": "checkbox",
                    "AXSubrole": "AXSegment",
                    "AXValue": "0"
                  },
                  "d": 3,
                  "e": "AXCheckBox",
                  "f": [
                    3437,
                    505,
                    21,
                    21
                  ],
                  "id": "7aee7e2e",
                  "m": [
                    "AXPress"
                  ],
                  "p": "AXWindow -> standard window -> Untitled 4.rtf -> AXStandardWindow -> AXToolbar -> toolbar -> AXGroup -> group -> text style -> AXCheckBox -> checkbox -> italic -> Italicize text -> AXSegment"
                },
                {
                  "a": {
                    "AXDescription": "underline",
                    "AXEnabled": "1",
                    "AXFocused": "0",
                    "AXHelp": "Underline text",
                    "AXRole": "AXCheckBox",
                    "AXRoleDescription": "checkbox",
                    "AXSubrole": "AXSegment",
                    "AXValue": "0"
                  },
                  "d": 3,
                  "e": "AXCheckBox",
                  "f": [
                    3458,
                    505,
                    21,
                    21
                  ],
                  "id": "f4e138b2",
                  "m": [
                    "AXPress"
                  ],
                  "p": "AXWindow -> standard window -> Untitled 4.rtf -> AXStandardWindow -> AXToolbar -> toolbar -> AXGroup -> group -> text style -> AXCheckBox -> checkbox -> underline -> Underline text -> AXSegment"
                }
              ],
              "d": 2,
              "e": "AXGroup",
              "f": [
                3415,
                505,
                64,
                21
              ],
              "id": "26b486c7",
              "p": "AXWindow -> standard window -> Untitled 4.rtf -> AXStandardWindow -> AXToolbar -> toolbar -> AXGroup -> group -> text style"
            },
            {
              "a": {
                "AXDescription": "text alignment",
                "AXEnabled": "1",
                "AXFocused": "0",
                "AXRole": "AXRadioGroup",
                "AXRoleDescription": "radio group",
                "AXValue": "<AXUIElement 0x327d8fbe0> {pid=41033}"
              },
              "c": [
                {
                  "a": {
                    "AXDescription": "align left",
                    "AXEnabled": "1",
                    "AXFocused": "0",
                    "AXHelp": "Align text to the left",
                    "AXRole": "AXRadioButton",
                    "AXRoleDescription": "radio button",
                    "AXSubrole": "AXSegment",
                    "AXValue": "1"
                  },
                  "d": 3,
                  "e": "AXRadioButton",
                  "f": [
                    3486,
                    505,
                    22,
                    21
                  ],
                  "id": "baff4bff",
                  "m": [
                    "AXPress"
                  ],
                  "p": "AXWindow -> standard window -> Untitled 4.rtf -> AXStandardWindow -> AXToolbar -> toolbar -> AXRadioGroup -> radio group -> text alignment -> AXRadioButton -> radio button -> align left -> Align text to the left -> AXSegment"
                },
                {
                  "a": {
                    "AXDescription": "align center",
                    "AXEnabled": "1",
                    "AXFocused": "0",
                    "AXHelp": "Center text",
                    "AXRole": "AXRadioButton",
                    "AXRoleDescription": "radio button",
                    "AXSubrole": "AXSegment",
                    "AXValue": "0"
                  },
                  "d": 3,
                  "e": "AXRadioButton",
                  "f": [
                    3508,
                    505,
                    21,
                    21
                  ],
                  "id": "1494f6e2",
                  "m": [
                    "AXPress"
                  ],
                  "p": "AXWindow -> standard window -> Untitled 4.rtf -> AXStandardWindow -> AXToolbar -> toolbar -> AXRadioGroup -> radio group -> text alignment -> AXRadioButton -> radio button -> align center -> Center text -> AXSegment"
                },
                {
                  "a": {
                    "AXDescription": "align right",
                    "AXEnabled": "1",
                    "AXFocused": "0",
                    "AXHelp": "Align text to the right",
                    "AXRole": "AXRadioButton",
                    "AXRoleDescription": "radio button",
                    "AXSubrole": "AXSegment",
                    "AXValue": "0"
                  },
                  "d": 3,
                  "e": "AXRadioButton",
                  "f": [
                    3529,
                    505,
                    21,
                    21
                  ],
                  "id": "3cc102b6",
                  "m": [
                    "AXPress"
                  ],
                  "p": "AXWindow -> standard window -> Untitled 4.rtf -> AXStandardWindow -> AXToolbar -> toolbar -> AXRadioGroup -> radio group -> text alignment -> AXRadioButton -> radio button -> align right -> Align text to the right -> AXSegment"
                },
                {
                  "a": {
                    "AXDescription": "fully justify",
                    "AXEnabled": "1",
                    "AXFocused": "0",
                    "AXHelp": "Justify text",
                    "AXRole": "AXRadioButton",
                    "AXRoleDescription": "radio button",
                    "AXSubrole": "AXSegment",
                    "AXValue": "0"
                  },
                  "d": 3,
                  "e": "AXRadioButton",
                  "f": [
                    3550,
                    505,
                    21,
                    21
                  ],
                  "id": "50c19bb7",
                  "m": [
                    "AXPress"
                  ],
                  "p": "AXWindow -> standard window -> Untitled 4.rtf -> AXStandardWindow -> AXToolbar -> toolbar -> AXRadioGroup -> radio group -> text alignment -> AXRadioButton -> radio button -> fully justify -> Justify text -> AXSegment"
                }
              ],
              "d": 2,
              "e": "AXRadioGroup",
              "f": [
                3486,
                505,
                85,
                21
              ],
              "id": "8a32d6b8",
              "p": "AXWindow -> standard window -> Untitled 4.rtf -> AXStandardWindow -> AXToolbar -> toolbar -> AXRadioGroup -> radio group -> text alignment"
            },
            {
              "a": {
                "AXDescription": "line spacing",
                "AXEnabled": "1",
                "AXFocused": "0",
                "AXHelp": "Line and paragraph spacing",
                "AXRole": "AXPopUpButton",
                "AXRoleDescription": "pop up button",
                "AXValue": "1.0"
              },
              "d": 2,
              "e": "AXPopUpButton",
              "f": [
                3578,
                505,
                41,
                21
              ],
              "id": "8bb8d4e8",
              "m": [
                "AXShowMenu",
                "AXPress"
              ],
              "p": "AXWindow -> standard window -> Untitled 4.rtf -> AXStandardWindow -> AXToolbar -> toolbar -> AXPopUpButton -> pop up button -> line spacing -> Line and paragraph spacing"
            },
            {
              "a": {
                "AXDescription": "list style",
                "AXEnabled": "1",
                "AXFocused": "0",
                "AXHelp": "List bullets and numbering",
                "AXRole": "AXMenuButton",
                "AXRoleDescription": "menu button"
              },
              "d": 2,
              "e": "AXMenuButton",
              "f": [
                3624,
                505,
                41,
                21
              ],
              "id": "673516c6",
              "m": [
                "AXShowMenu",
                "AXPress"
              ],
              "p": "AXWindow -> standard window -> Untitled 4.rtf -> AXStandardWindow -> AXToolbar -> toolbar -> AXMenuButton -> menu button -> list style -> List bullets and numbering"
            }
          ],
          "d": 1,
          "e": "AXToolbar",
          "f": [
            3090,
            501,
            586,
            28
          ],
          "id": "49800573",
          "p": "AXWindow -> standard window -> Untitled 4.rtf -> AXStandardWindow -> AXToolbar -> toolbar"
        },
        {
          "a": {
            "AXEnabled": "1",
            "AXFocused": "0",
            "AXRole": "AXButton",
            "AXRoleDescription": "close button",
            "AXSubrole": "AXCloseButton"
          },
          "d": 1,
          "e": "AXButton",
          "f": [
            3097,
            479,
            14,
            16
          ],
          "id": "c6e9fa93",
          "m": [
            "AXPress"
          ],
          "p": "AXWindow -> standard window -> Untitled 4.rtf -> AXStandardWindow -> AXButton -> close button -> AXCloseButton"
        },
        {
          "a": {
            "AXEnabled": "1",
            "AXFocused": "0",
            "AXHelp": "this button also has an action to zoom the window",
            "AXRole": "AXButton",
            "AXRoleDescription": "full screen button",
            "AXSubrole": "AXFullScreenButton"
          },
          "c": [
            {
              "a": {
                "AXFocused": "0",
                "AXRole": "AXGroup",
                "AXRoleDescription": "group"
              },
              "c": [
                {
                  "a": {
                    "AXFocused": "0",
                    "AXRole": "AXGroup",
                    "AXRoleDescription": "group"
                  },
                  "d": 3,
                  "e": "AXGroup",
                  "f": [
                    3137,
                    479,
                    14,
                    16
                  ],
                  "id": "73edd2d6",
                  "p": "AXWindow -> standard window -> Untitled 4.rtf -> AXStandardWindow -> AXButton -> full screen button -> this button also has an action to zoom the window -> AXFullScreenButton -> AXGroup -> group -> AXGroup -> group"
                }
              ],
              "d": 2,
              "e": "AXGroup",
              "f": [
                3137,
                479,
                14,
                16
              ],
              "id": "e4976f4f",
              "p": "AXWindow -> standard window -> Untitled 4.rtf -> AXStandardWindow -> AXButton -> full screen button -> this button also has an action to zoom the window -> AXFullScreenButton -> AXGroup -> group"
            }
          ],
          "d": 1,
          "e": "AXButton",
          "f": [
            3137,
            479,
            14,
            16
          ],
          "id": "b06936cd",
          "m": [
            "AXPress",
            "AXZoomWindow",
            "AXShowMenu"
          ],
          "p": "AXWindow -> standard window -> Untitled 4.rtf -> AXStandardWindow -> AXButton -> full screen button -> this button also has an action to zoom the window -> AXFullScreenButton"
        },
        {
          "a": {
            "AXEnabled": "1",
            "AXFocused": "0",
            "AXRole": "AXButton",
            "AXRoleDescription": "minimize button",
            "AXSubrole": "AXMinimizeButton"
          },
          "d": 1,
          "e": "AXButton",
          "f": [
            3117,
            479,
            14,
            16
          ],
          "id": "9ca0e5d3",
          "m": [
            "AXPress"
          ],
          "p": "AXWindow -> standard window -> Untitled 4.rtf -> AXStandardWindow -> AXButton -> minimize button -> AXMinimizeButton"
        },
        {
          "a": {
            "AXDescription": "document actions",
            "AXEnabled": "0",
            "AXFocused": "0",
            "AXRole": "AXMenuButton",
            "AXRoleDescription": "menu button",
            "AXTitle": "Edited"
          },
          "d": 1,
          "e": "AXMenuButton",
          "f": [
            3426,
            478,
            51,
            16
          ],
          "id": "6f8868da",
          "m": [
            "AXPress",
            "AXShowMenu"
          ],
          "p": "AXWindow -> standard window -> Untitled 4.rtf -> AXStandardWindow -> AXMenuButton -> menu button -> Edited -> document actions"
        },
        {
          "a": {
            "AXEnabled": "0",
            "AXFocused": "0",
            "AXRole": "AXStaticText",
            "AXRoleDescription": "text",
            "AXValue": "—"
          },
          "d": 1,
          "e": "AXStaticText",
          "f": [
            3409,
            478,
            16,
            16
          ],
          "id": "c2de2bbb",
          "p": "AXWindow -> standard window -> Untitled 4.rtf -> AXStandardWindow -> AXStaticText -> text"
        },
        {
          "a": {
            "AXEnabled": "1",
            "AXFocused": "0",
            "AXRole": "AXImage",
            "AXRoleDescription": "image",
            "AXTitle": "Untitled 4.rtf"
          },
          "d": 1,
          "e": "AXImage",
          "f": [
            3302,
            478,
            16,
            16
          ],
          "id": "da3c7d89",
          "p": "AXWindow -> standard window -> Untitled 4.rtf -> AXStandardWindow -> AXImage -> image -> Untitled 4.rtf"
        },
        {
          "a": {
            "AXEnabled": "1",
            "AXFocused": "0",
            "AXRole": "AXStaticText",
            "AXRoleDescription": "text",
            "AXValue": "Untitled 4.rtf"
          },
          "d": 1,
          "e": "AXStaticText",
          "f": [
            3320,
            478,
            89,
            16
          ],
          "id": "c2de2bbb",
          "p": "AXWindow -> standard window -> Untitled 4.rtf -> AXStandardWindow -> AXStaticText -> text"
        }
      ],
      "d": 0,
      "e": "AXWindow",
      "f": [
        3090,
        473,
        586,
        476
      ],
      "id": "49b53b35",
      "m": [
        "AXRaise"
      ],
      "main": true,
      "p": "AXWindow -> standard window -> Untitled 4.rtf -> AXStandardWindow"
    }
  ],
  "ts": "2025-02-26T17:04:34Z"
}
```
